### PR TITLE
Adding support textContent Attribute

### DIFF
--- a/OpenRPA.NM/NMElement.cs
+++ b/OpenRPA.NM/NMElement.cs
@@ -180,8 +180,10 @@ namespace OpenRPA.NM
                 {
                     if (Attributes.ContainsKey("text")) return Attributes["text"].ToString();
                     if (Attributes.ContainsKey("innertext")) return Attributes["innertext"].ToString();
+                    if (Attributes.ContainsKey("textcontent")) return Attributes["textcontent"].ToString();
                 }
                 if (Attributes.ContainsKey("text")) return Attributes["text"].ToString();
+                if (Attributes.ContainsKey("textcontent")) return Attributes["textcontent"].ToString();
                 if (Attributes.ContainsKey("innertext"))
                 {
                     var text = Attributes["innertext"].ToString();
@@ -197,6 +199,7 @@ namespace OpenRPA.NM
                     Refresh();
                     if (Attributes.ContainsKey("text")) return Attributes["text"].ToString();
                     if (Attributes.ContainsKey("innertext")) return Attributes["innertext"].ToString();
+                    if (Attributes.ContainsKey("textcontent")) return Attributes["textcontent"].ToString();
                 }
                 return null;
             }


### PR DESCRIPTION
The textContent property returns the text content of the specified node element, This can be a proper alternative for InnerText property in the case of returning a null value.