### PR TITLE
Fix for extension .dll's not loading into toolbox

### DIFF
--- a/OpenRPA/App.xaml.cs
+++ b/OpenRPA/App.xaml.cs
@@ -164,7 +164,7 @@ namespace OpenRPA
                 assemblyPath = System.IO.Path.Combine(folderPath, new AssemblyName(args.Name).Name + ".dll");
                 if (System.IO.File.Exists(assemblyPath)) return Assembly.LoadFrom(assemblyPath);
 
-                folderPath = Interfaces.Extensions.ProjectsDirectory;
+                folderPath = Path.Combine(Interfaces.Extensions.ProjectsDirectory, "extensions");
                 assemblyPath = System.IO.Path.Combine(folderPath, new AssemblyName(args.Name).Name + ".dll");
                 if (System.IO.File.Exists(assemblyPath)) return Assembly.LoadFrom(assemblyPath);
 

--- a/OpenRPA/Views/wfToolbox.xaml.cs
+++ b/OpenRPA/Views/wfToolbox.xaml.cs
@@ -148,8 +148,9 @@ namespace OpenRPA.Views
                             }
                         }
                     }
-                    catch (Exception)
+                    catch (Exception ex)
                     {
+                        Log.Error(ex.ToString());
                     }
                 }
 


### PR DESCRIPTION
Fixed a bug where .dll's from extensions folder would not be loaded properly by: changing the lookup from ProjectsDirectory to ProjectsDirectory/extensions.

NOTE: AFAIK ProjectsDirectory directly should not contain .dll's, so instead of adding a new location, changing that lookup.